### PR TITLE
feat: Implement Quiz Completion screen

### DIFF
--- a/app/src/main/java/com/DeepSoni/vedaconnect/AppNavigation.kt
+++ b/app/src/main/java/com/DeepSoni/vedaconnect/AppNavigation.kt
@@ -15,7 +15,11 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.DeepSoni.vedaconnect.Data.LeaderboardEntry
+import com.DeepSoni.vedaconnect.Data.Medal
+import com.DeepSoni.vedaconnect.Data.QuizResult
 import com.DeepSoni.vedaconnect.Repository.MantraRepository
+import com.DeepSoni.vedaconnect.feature.QuizCompleteScreen
 import com.DeepSoni.vedaconnect.feature.community.CommunityScreen
 import com.DeepSoni.vedaconnect.feature.home.HomeScreen
 import com.DeepSoni.vedaconnect.feature.notification.NotificationScreen
@@ -36,6 +40,8 @@ sealed class Screen(val route: String, val label: String? = null, val icon: Imag
     object Content : Screen("content", "Content", Icons.Outlined.AutoStories)
     object Quiz : Screen("quiz", "Quiz", Icons.Outlined.WorkspacePremium)
     object Community : Screen("community", "Community", Icons.Outlined.Article)
+
+    object QuizComplete : Screen("quizComplete")
     object Notification : Screen("notification")
     object MantraDetail : Screen("detail/{mantraId}") {
         fun createRoute(mantraId: String) = "detail/$mantraId"
@@ -95,6 +101,34 @@ fun AppNavigation() {
             // Quiz Screen (with bottom bar)
             composable(Screen.Quiz.route) {
                 QuizScreen(navController = navController)
+            }
+
+            composable(Screen.QuizComplete.route) {
+                // Dummy data for demonstration
+                val dummyQuizResult = QuizResult(
+                    correctAnswers = 7,
+                    totalQuestions = 10,
+                    pointsEarned = 70,
+                    totalScore = 850
+                )
+                val dummyLeaderboard = listOf(
+                    LeaderboardEntry("Priya K.", 1, 950, medal = Medal.GOLD),
+                    LeaderboardEntry("Rahul M.", 2, 920, medal = Medal.SILVER),
+                    LeaderboardEntry("Ananya S.", 3, 890, medal = Medal.BRONZE),
+                    LeaderboardEntry("You", 4, 850, isCurrentUser = true),
+                    LeaderboardEntry("Dr. Sharma", 5, 820)
+                )
+
+                QuizCompleteScreen(
+                    quizResult = dummyQuizResult,
+                    leaderboardEntries = dummyLeaderboard,
+                    onViewFullLeaderboard = {
+                        // Navigate back to the main quiz screen
+                        navController.navigate(Screen.Quiz.route) {
+                            popUpTo(Screen.Quiz.route) { inclusive = true }
+                        }
+                    }
+                )
             }
 
             // Content Screen (with bottom bar)

--- a/app/src/main/java/com/DeepSoni/vedaconnect/data/Medal.kt
+++ b/app/src/main/java/com/DeepSoni/vedaconnect/data/Medal.kt
@@ -1,0 +1,5 @@
+package com.DeepSoni.vedaconnect.Data
+
+enum class Medal {
+    GOLD, SILVER, BRONZE
+}

--- a/app/src/main/java/com/DeepSoni/vedaconnect/data/data.kt
+++ b/app/src/main/java/com/DeepSoni/vedaconnect/data/data.kt
@@ -13,3 +13,18 @@ data class Mantra(
     val preview: String,
     val audioResId: Int? = null
 )
+
+data class QuizResult(
+    val correctAnswers: Int,
+    val totalQuestions: Int,
+    val pointsEarned: Int,
+    val totalScore: Int
+)
+
+data class LeaderboardEntry(
+    val name: String,
+    val rank: Int,
+    val points: Int,
+    val isCurrentUser: Boolean = false,
+    val medal: Medal? = null
+)

--- a/app/src/main/java/com/DeepSoni/vedaconnect/feature/quiz/QuizCompletionScreen.kt
+++ b/app/src/main/java/com/DeepSoni/vedaconnect/feature/quiz/QuizCompletionScreen.kt
@@ -1,0 +1,383 @@
+package com.DeepSoni.vedaconnect.feature
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.DeepSoni.vedaconnect.Data.LeaderboardEntry
+import com.DeepSoni.vedaconnect.Data.Medal
+import com.DeepSoni.vedaconnect.Data.QuizResult
+
+
+// Color Definitions
+private val PrimaryGreen = Color(0xFF00C853)
+private val OrangeButton = Color(0xFFFF9800)
+private val GrayText = Color(0xFF757575)
+private val BorderGold = Color(0xFFD4AF37)
+
+@Composable
+fun QuizCompleteScreen(
+    quizResult: QuizResult,
+    leaderboardEntries: List<LeaderboardEntry>,
+    onViewFullLeaderboard: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color(0xFFF5F5F5))
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // Quiz Complete Header
+        item {
+            QuizCompleteHeader()
+        }
+
+        // Score Card
+        item {
+            ScoreCard(quizResult)
+        }
+
+        // Leaderboard Section
+        item {
+            LeaderboardHeader()
+        }
+
+        // Leaderboard Items
+        items(leaderboardEntries) { entry ->
+            LeaderboardItem(entry)
+        }
+
+        // View Full Leaderboard Button
+        item {
+            ViewFullLeaderboardButton(onClick = onViewFullLeaderboard)
+        }
+
+        // Bottom spacing
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun QuizCompleteHeader() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = PrimaryGreen)
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp)
+        ) {
+            Text(
+                text = "Quiz Complete! 🎉",
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.White
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Great effort this week",
+                fontSize = 16.sp,
+                color = Color.White.copy(alpha = 0.9f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScoreCard(quizResult: QuizResult) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = PrimaryGreen)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // Trophy Icon
+            Text(
+                text = "🏆",
+                fontSize = 64.sp
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Score
+            Text(
+                text = "${quizResult.correctAnswers}/${quizResult.totalQuestions}",
+                fontSize = 56.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.White
+            )
+
+            Text(
+                text = "Correct Answers",
+                fontSize = 18.sp,
+                color = Color.White.copy(alpha = 0.9f)
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Points Row
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "+${quizResult.pointsEarned}",
+                        fontSize = 28.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
+                    )
+                    Text(
+                        text = "Points",
+                        fontSize = 14.sp,
+                        color = Color.White.copy(alpha = 0.9f)
+                    )
+                }
+
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "${quizResult.totalScore}",
+                        fontSize = 28.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
+                    )
+                    Text(
+                        text = "Total Score",
+                        fontSize = 14.sp,
+                        color = Color.White.copy(alpha = 0.9f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LeaderboardHeader() {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "Leaderboard",
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.Black
+        )
+        Text(
+            text = "This Week",
+            fontSize = 14.sp,
+            color = GrayText
+        )
+    }
+}
+
+@Composable
+private fun LeaderboardItem(entry: LeaderboardEntry) {
+    val backgroundColor = if (entry.isCurrentUser) {
+        Color(0xFFFFF8E1)
+    } else {
+        Color.White
+    }
+
+    val borderColor = if (entry.isCurrentUser) {
+        BorderGold
+    } else {
+        Color.Transparent
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = backgroundColor),
+        border = if (entry.isCurrentUser) {
+            androidx.compose.foundation.BorderStroke(2.dp, borderColor)
+        } else null
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.weight(1f)
+            ) {
+                // Medal or Avatar
+                if (entry.medal != null) {
+                    MedalIcon(entry.medal)
+                } else {
+                    DefaultAvatar()
+                }
+
+                Spacer(modifier = Modifier.width(12.dp))
+
+                Column {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = entry.name,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = Color.Black
+                        )
+                        if (entry.isCurrentUser) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = "You",
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = Color.Black,
+                                modifier = Modifier
+                                    .background(
+                                        Color(0xFFE0E0E0),
+                                        RoundedCornerShape(4.dp)
+                                    )
+                                    .padding(horizontal = 6.dp, vertical = 2.dp)
+                            )
+                        }
+                    }
+                    Text(
+                        text = "Rank #${entry.rank}",
+                        fontSize = 12.sp,
+                        color = GrayText
+                    )
+                }
+            }
+
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = "${entry.points}",
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.Black
+                )
+                Text(
+                    text = "points",
+                    fontSize = 12.sp,
+                    color = GrayText
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MedalIcon(medal: Medal) {
+    val emoji = when (medal) {
+        Medal.GOLD -> "🥇"
+        Medal.SILVER -> "🥈"
+        Medal.BRONZE -> "🥉"
+    }
+
+    Box(
+        modifier = Modifier
+            .size(48.dp)
+            .clip(CircleShape)
+            .background(Color(0xFFF5F5F5)),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = emoji,
+            fontSize = 28.sp
+        )
+    }
+}
+
+@Composable
+private fun DefaultAvatar() {
+    Box(
+        modifier = Modifier
+            .size(48.dp)
+            .clip(CircleShape)
+            .background(Color(0xFFE0E0E0)),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "👤",
+            fontSize = 24.sp
+        )
+    }
+}
+
+@Composable
+private fun ViewFullLeaderboardButton(onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = OrangeButton
+        )
+    ) {
+        Text(
+            text = "End",
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.White
+        )
+    }
+}
+
+// Preview with dummy data
+@Composable
+fun PreviewQuizCompleteScreen() {
+    val dummyQuizResult = QuizResult(
+        correctAnswers = 7,
+        totalQuestions = 10,
+        pointsEarned = 70,
+        totalScore = 850
+    )
+
+    val dummyLeaderboard = listOf(
+        LeaderboardEntry("Priya K.", 1, 950, medal = Medal.GOLD),
+        LeaderboardEntry("Rahul M.", 2, 920, medal = Medal.SILVER),
+        LeaderboardEntry("Ananya S.", 3, 890, medal = Medal.BRONZE),
+        LeaderboardEntry("You", 4, 850, isCurrentUser = true),
+        LeaderboardEntry("Dr. Sharma", 5, 820)
+    )
+
+    QuizCompleteScreen(
+        quizResult = dummyQuizResult,
+        leaderboardEntries = dummyLeaderboard,
+        onViewFullLeaderboard = { /* Handle click */ }  // navigate to the Quiz Screen
+    )
+}

--- a/app/src/main/java/com/DeepSoni/vedaconnect/feature/quiz/QuizScreen.kt
+++ b/app/src/main/java/com/DeepSoni/vedaconnect/feature/quiz/QuizScreen.kt
@@ -1,6 +1,7 @@
 package com.DeepSoni.vedaconnect.feature.weeklyquiz
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -11,17 +12,25 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
 import androidx.navigation.NavHostController
+import com.DeepSoni.vedaconnect.Screen
 
+// Color definitions used within this screen
 val OrangePrimary = Color(0xFFF77F00)
 val LightOrangeBg: Color = Color(0xFFFFEEE0)
 
+/**
+ * The main entry point for the Quiz feature screen.
+ * It displays the header, the current weekly challenge, and a list of previous quizzes.
+ */
 @Composable
 fun QuizScreen(navController: NavHostController) {
     val scrollState = rememberScrollState()
@@ -31,7 +40,7 @@ fun QuizScreen(navController: NavHostController) {
             .fillMaxSize()
             .background(Color.White)
     ) {
-        // Header
+        // Header section with the orange background
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -58,7 +67,7 @@ fun QuizScreen(navController: NavHostController) {
             }
         }
 
-        // Body Content
+        // Scrollable body content
         Column(
             modifier = Modifier
                 .weight(1f)
@@ -68,19 +77,29 @@ fun QuizScreen(navController: NavHostController) {
             Spacer(modifier = Modifier.height(16.dp))
 
             WeeklyChallengeCard(
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                navController = navController
             )
 
             Spacer(modifier = Modifier.height(16.dp))
-            PreviousWeekSection()
-            Spacer(modifier = Modifier.height(60.dp))
+
+            // The list of previous weeks now requires the NavController
+            PreviousWeekSection(
+                modifier = Modifier.fillMaxWidth(),
+                navController = navController
+            )
+
+            Spacer(modifier = Modifier.height(60.dp)) // Padding at the bottom
         }
     }
 }
 
-
+/**
+ * Displays a list of previous weekly quizzes. Each item in the list is clickable
+ * and navigates to the QuizComplete screen.
+ */
 @Composable
-fun PreviousWeekSection(modifier: Modifier = Modifier) {
+fun PreviousWeekSection(modifier: Modifier = Modifier, navController: NavController) {
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -93,7 +112,7 @@ fun PreviousWeekSection(modifier: Modifier = Modifier) {
         )
         Spacer(modifier = Modifier.height(8.dp))
 
-        // Hardcoded list for demonstration
+        // Hardcoded list for demonstration purposes
         val previousWeeks = listOf(
             "Week 1" to 0.8f,
             "Week 2" to 0.6f,
@@ -106,7 +125,14 @@ fun PreviousWeekSection(modifier: Modifier = Modifier) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(Color.LightGray, shape = RoundedCornerShape(10.dp))
+                    // Apply clipping before clickable to ensure the ripple effect respects the rounded corners
+                    .clip(RoundedCornerShape(10.dp))
+                    .clickable {
+                        // Navigate to the completion screen when a previous quiz is clicked.
+                        // In a real app, you would pass a specific quiz ID here.
+                        navController.navigate(Screen.QuizComplete.route)
+                    }
+                    .background(Color.LightGray) // The shape is now handled by the clip modifier
                     .padding(16.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
@@ -119,7 +145,7 @@ fun PreviousWeekSection(modifier: Modifier = Modifier) {
                 Spacer(modifier = Modifier.width(8.dp))
                 Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.weight(1f)) {
                     LinearProgressIndicator(
-                        progress = progress,
+                        progress = { progress }, // Updated syntax for progress
                         modifier = Modifier
                             .weight(1f)
                             .height(10.dp),
@@ -145,6 +171,9 @@ fun PreviousWeekSection(modifier: Modifier = Modifier) {
     }
 }
 
+/**
+ * A generic card for displaying statistics. (Not used in the final layout but kept for completeness).
+ */
 @Composable
 fun StateCard(icon: ImageVector, label: String, value: String, modifier: Modifier = Modifier) {
     Card(
@@ -185,8 +214,12 @@ fun StateCard(icon: ImageVector, label: String, value: String, modifier: Modifie
     }
 }
 
+/**
+ * A card that presents the current weekly challenge and a button to start it.
+ * The "Start Quiz" button's navigation has been removed as requested.
+ */
 @Composable
-fun WeeklyChallengeCard(modifier: Modifier = Modifier) {
+fun WeeklyChallengeCard(modifier: Modifier = Modifier, navController: NavHostController) {
     Card(
         modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(16.dp),
@@ -198,7 +231,6 @@ fun WeeklyChallengeCard(modifier: Modifier = Modifier) {
                 .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // Placeholder for an icon
             Icon(
                 imageVector = Icons.Outlined.WorkspacePremium,
                 contentDescription = "Weekly Challenge Icon",
@@ -236,8 +268,13 @@ fun WeeklyChallengeCard(modifier: Modifier = Modifier) {
             }
             Spacer(modifier = Modifier.height(24.dp))
 
+            // The button to start the current week's quiz
             Button(
-                onClick = { /* TODO: Handle quiz start */ },
+                onClick = {
+                    // TODO: Implement navigation to the actual quiz-taking screen.
+                    // For now, this button does nothing as per the request.
+                    // Example: navController.navigate("quiz_questions_route")
+                },
                 shape = RoundedCornerShape(16.dp),
                 colors = ButtonDefaults.buttonColors(containerColor = OrangePrimary),
                 modifier = Modifier
@@ -250,6 +287,9 @@ fun WeeklyChallengeCard(modifier: Modifier = Modifier) {
     }
 }
 
+/**
+ * A small composable to display a piece of quiz information (e.g., "10 Questions").
+ */
 @Composable
 fun QuizInfoItem(value: String, label: String) {
     Column(


### PR DESCRIPTION
- Implemented the `QuizCompleteScreen` using Jetpack Compose, which displays:
    - A "Quiz Complete!" header and a detailed score card showing correct answers, points earned, and total score.
    - A "Leaderboard" section listing the top players for the week.
    - Special highlighting for the current user's entry in the leaderboard.
    - Medals (🥇, 🥈, 🥉) for the top three ranked users.
- Added new data models: `QuizResult`, `LeaderboardEntry`, and a `Medal` enum.
- Created a new navigation route `Screen.QuizComplete` and integrated the screen into `AppNavigation.kt` with dummy data.
- Made previous quizzes on the `QuizScreen` clickable, navigating to the new `QuizCompleteScreen`.
- The "View Full Leaderboard" button on the completion screen now navigates back to the main `QuizScreen`.